### PR TITLE
Fix CLI informational output to use stderr instead of stdout

### DIFF
--- a/src/bin/wiim_control.rs
+++ b/src/bin/wiim_control.rs
@@ -107,47 +107,47 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         Commands::Play => {
             client.resume().await?;
-            println!("▶️ Playing");
+            eprintln!("▶️ Playing");
         }
         Commands::Pause => {
             client.pause().await?;
-            println!("⏸️ Paused");
+            eprintln!("⏸️ Paused");
         }
         Commands::Toggle => {
             client.toggle_play_pause().await?;
-            println!("⏯️ Toggled");
+            eprintln!("⏯️ Toggled");
         }
         Commands::Stop => {
             client.stop().await?;
-            println!("⏹️ Stopped");
+            eprintln!("⏹️ Stopped");
         }
         Commands::Next => {
             client.next_track().await?;
-            println!("⏭️ Next track");
+            eprintln!("⏭️ Next track");
         }
         Commands::Prev => {
             client.previous_track().await?;
-            println!("⏮️ Previous track");
+            eprintln!("⏮️ Previous track");
         }
         Commands::Volume { level } => {
             client.set_volume(level).await?;
-            println!("🔊 Volume set to {level}%");
+            eprintln!("🔊 Volume set to {level}%");
         }
         Commands::VolumeUp { step } => {
             let new_volume = client.volume_up(Some(step)).await?;
-            println!("🔊 Volume up to {new_volume}%");
+            eprintln!("🔊 Volume up to {new_volume}%");
         }
         Commands::VolumeDown { step } => {
             let new_volume = client.volume_down(Some(step)).await?;
-            println!("🔊 Volume down to {new_volume}%");
+            eprintln!("🔊 Volume down to {new_volume}%");
         }
         Commands::Mute => {
             client.mute().await?;
-            println!("🔇 Muted");
+            eprintln!("🔇 Muted");
         }
         Commands::Unmute => {
             client.unmute().await?;
-            println!("🔊 Unmuted");
+            eprintln!("🔊 Unmuted");
         }
     }
 
@@ -266,7 +266,7 @@ async fn load_config(config_path: &Option<PathBuf>) -> Result<Config, Box<dyn st
                 let config_content = format!("device_ip = \"{}\"\n", default_config.device_ip);
                 let config_file = config_dir.join("config.toml");
                 fs::write(&config_file, config_content).await?;
-                println!("Created default config at: {}", config_file.display());
+                eprintln!("Created default config at: {}", config_file.display());
                 return Ok(default_config);
             }
 


### PR DESCRIPTION
## Summary
Fixes issue #3 by updating CLI informational messages to use stderr instead of stdout.

This change separates informational messages from actual command output, preventing interference with structured output parsing (especially JSON mode) and improving CLI tool composability.

## Changes Made
- ✅ Changed 11 command confirmation messages to use `eprintln\!` instead of `println\!`:
  - Play/Pause/Toggle/Stop messages
  - Next/Previous track messages  
  - Volume control messages
  - Mute/Unmute messages
- ✅ Updated config file creation message to use `eprintln\!`
- ✅ Preserved `println\!` for actual command output (status text/JSON on lines 170, 191)

## Benefits
- **JSON parsing**: Tools can now parse JSON output without interference from informational messages
- **Shell redirection**: `wiim-control status > output.txt` will only capture the status data
- **Unix convention**: Follows the standard of using stdout for data and stderr for logs/info
- **Tool composability**: Better integration with shell pipelines and automation tools

## Testing
- ✅ Verified build succeeds with `cargo build`
- ✅ Confirmed formatting and linting pass with `cargo fmt && cargo clippy`
- ✅ Tested shell redirection to confirm:
  - Informational messages go to stderr
  - Command output goes to stdout
  - JSON output is not contaminated with log messages

## Test plan
To verify the fix:
```bash
# Test informational messages go to stderr
wiim-control play 2>/dev/null  # Should suppress confirmation message
wiim-control play > /tmp/out.txt 2> /tmp/err.txt  # Check both files

# Test command output goes to stdout  
wiim-control status --format json | jq .  # Should parse cleanly
wiim-control status > status.txt  # Should capture only status data
```

🤖 Generated with [Claude Code](https://claude.ai/code)