### PR TITLE
Add HTTP client timeout configuration to prevent hanging requests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@
 use reqwest::Client;
 use serde::Deserialize;
 use std::fmt;
+use std::time::Duration;
 use thiserror::Error;
 
 /// Errors that can occur when using the WiiM API
@@ -186,6 +187,8 @@ impl WiimClient {
         // Configure client to accept self-signed certificates (WiiM devices use them)
         let client = Client::builder()
             .danger_accept_invalid_certs(true)
+            .connect_timeout(Duration::from_secs(5))
+            .timeout(Duration::from_secs(10))
             .build()
             .expect("Failed to create HTTP client");
 


### PR DESCRIPTION
## Summary
- Added HTTP client timeout configuration to prevent hanging requests on unresponsive WiiM devices
- Connect timeout: 5 seconds for initial connection establishment
- Request timeout: 10 seconds for complete request/response cycle
- Added `std::time::Duration` import for timeout configuration

## Changes Made
- **src/lib.rs**: Added `use std::time::Duration` import
- **src/lib.rs**: Modified `WiimClient::new()` to configure HTTP client with timeouts:
  - `.connect_timeout(Duration::from_secs(5))`
  - `.timeout(Duration::from_secs(10))`

## Benefits
- Prevents hanging on unresponsive WiiM devices
- Improves reliability for CLI tools and waybar integration
- More predictable behavior for network operations
- Foundation for future retry logic

## Testing
- All existing unit tests pass
- All integration tests remain functional
- Code formatting and linting checks pass
- No breaking changes to public API

## Test plan
- [x] Run `cargo build` - builds successfully
- [x] Run `cargo test` - all tests pass
- [x] Run `cargo fmt` - formatting correct
- [x] Run `cargo clippy` - no linting issues
- [x] Verify no breaking changes to public API
- [x] Integration tests continue to work with timeouts

🤖 Generated with [Claude Code](https://claude.ai/code)